### PR TITLE
Fix build against current mrpt master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,13 @@ find_package(catkin REQUIRED COMPONENTS
 # find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(MRPT REQUIRED)
-message(WARNING "Found MRPT: " ${MRPT_VERSION})
+message(STATUS "Found MRPT: " ${MRPT_VERSION})
 if("${MRPT_VERSION}" VERSION_LESS "1.9.9")
 	# MRPT<2.0
 	find_package(MRPT REQUIRED base)
 else()
 	# MRPT>=2.0
-    find_package(MRPT REQUIRED poses)
+	find_package(MRPT REQUIRED poses)
 endif()
 
 ## Uncomment this if the package has a setup.py. This macro ensures

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set (CMAKE_CXX_STANDARD 11)
 
 project(pose_cov_ops)
 
@@ -16,28 +15,14 @@ find_package(catkin REQUIRED COMPONENTS
 # find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(MRPT REQUIRED)
-message(STATUS "Found MRPT: " ${MRPT_VERSION})
+message(WARNING "Found MRPT: " ${MRPT_VERSION})
 if("${MRPT_VERSION}" VERSION_LESS "1.9.9")
 	# MRPT<2.0
 	find_package(MRPT REQUIRED base)
 else()
 	# MRPT>=2.0
-	set (CMAKE_CXX_STANDARD 14) # C++14 actually only needed when building
-	find_package(MRPT REQUIRED poses)
+    find_package(MRPT REQUIRED poses)
 endif()
-
-
-if (CMAKE_COMPILER_IS_GNUCXX)
-	# High level of warnings.
-	# The -Wno-long-long is required in 64bit systems when including sytem headers.
-	# The -Wno-variadic-macros was needed for Eigen3, StdVector.h
-	add_compile_options(-Wall -Wno-long-long -Wno-variadic-macros)
-	# Workaround: Eigen <3.4 produces *tons* of warnings in GCC >=6. See http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
-	if (NOT ${CMAKE_CXX_COMPILER_VERSION} LESS "6.0")
-		add_compile_options(-Wno-ignored-attributes -Wno-int-in-bool-context)
-	endif()
-endif()
-
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -124,6 +109,34 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME}
    src/${PROJECT_NAME}.cpp
 )
+
+if("${MRPT_VERSION}" VERSION_LESS "1.9.9")
+    set(CMAKE_CXX_STANDARD 14)
+else()
+    #Need to enable C++17
+    #We take into account that ubuntu 16.04 LTS only has cmake 3.5
+    if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
+        #Manually set c++17 which is not supported before cmake 3.8.0
+        if (CMAKE_COMPILER_IS_GNUCXX)
+            target_compile_options(${PROJECT_NAME} PUBLIC -std=gnu++17)
+        elseif()
+            message(FATAL_ERROR "You have to enable C++17 for your compiler here")
+        endif()
+    else()
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+endif()
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+	# High level of warnings.
+	# The -Wno-long-long is required in 64bit systems when including sytem headers.
+	# The -Wno-variadic-macros was needed for Eigen3, StdVector.h
+	target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wno-long-long -Wno-variadic-macros)
+	# Workaround: Eigen <3.4 produces *tons* of warnings in GCC >=6. See http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
+	if (NOT ${CMAKE_CXX_COMPILER_VERSION} LESS "6.0")
+		target_compile_options(${PROJECT_NAME} PUBLIC -Wno-ignored-attributes -Wno-int-in-bool-context)
+	endif()
+endif()
 
 ## Declare a cpp executable
 # add_executable(pose_cov_ops_node src/pose_cov_ops_node.cpp)


### PR DESCRIPTION
Added c++17 activation to be able to build
Use target_compile_options instead of add_compile_options